### PR TITLE
re-enable zlib and nvdec, properly disable OSS audio, add nghttp2 support and clean-up

### DIFF
--- a/gpac-aarch64-nvdec.patch
+++ b/gpac-aarch64-nvdec.patch
@@ -1,0 +1,33 @@
+diff -up gpac-2.2.1/src/filters/dec_nvdec_sdk.c.orig gpac-2.2.1/src/filters/dec_nvdec_sdk.c
+--- gpac-2.2.1/src/filters/dec_nvdec_sdk.c.orig	2023-04-24 12:57:53.000000000 +0000
++++ gpac-2.2.1/src/filters/dec_nvdec_sdk.c	2024-03-12 11:42:51.690883435 +0000
+@@ -197,7 +197,7 @@ tcuvidDecodePicture                   *c
+ tcuvidMapVideoFrame                   *cuvidMapVideoFrame;
+ tcuvidUnmapVideoFrame                 *cuvidUnmapVideoFrame;
+ 
+-#if defined(WIN64) || defined(_WIN64) || defined(__x86_64) || defined(AMD64) || defined(_M_AMD64)
++#if defined(WIN64) || defined(_WIN64) || defined(__x86_64) || defined(AMD64) || defined(_M_AMD64) || defined(__aarch64__)
+ tcuvidMapVideoFrame64                 *cuvidMapVideoFrame64;
+ tcuvidUnmapVideoFrame64               *cuvidUnmapVideoFrame64;
+ #endif
+diff -up gpac-2.2.1/src/filters/dec_nvdec_sdk.h.orig gpac-2.2.1/src/filters/dec_nvdec_sdk.h
+--- gpac-2.2.1/src/filters/dec_nvdec_sdk.h.orig	2023-04-24 12:57:53.000000000 +0000
++++ gpac-2.2.1/src/filters/dec_nvdec_sdk.h	2024-03-12 11:43:53.158031385 +0000
+@@ -1821,7 +1821,7 @@ typedef void *CUDADRIVER;
+ 
+ 
+ 
+-#if defined(__x86_64) || defined(AMD64) || defined(_M_AMD64)
++#if defined(__x86_64) || defined(AMD64) || defined(_M_AMD64) || defined(__aarch64__)
+ #if (CUDA_VERSION >= 3020) && (!defined(CUDA_FORCE_API_VERSION) || (CUDA_FORCE_API_VERSION >= 3020))
+ #define __CUVID_DEVPTR64
+ #endif
+@@ -2526,7 +2526,7 @@ typedef CUresult CUDAAPI tcuvidMapVideoF
+ typedef CUresult CUDAAPI tcuvidUnmapVideoFrame(CUvideodecoder hDecoder, unsigned int DevPtr);
+ #endif
+ 
+-#if defined(WIN64) || defined(_WIN64) || defined(__x86_64) || defined(AMD64) || defined(_M_AMD64)
++#if defined(WIN64) || defined(_WIN64) || defined(__x86_64) || defined(AMD64) || defined(_M_AMD64) || defined(__aarch64__)
+ /**
+  * \fn CUresult CUDAAPI cuvidMapVideoFrame64(CUvideodecoder hDecoder, int nPicIdx, unsigned long long *pDevPtr, unsigned int *pPitch, CUVIDPROCPARAMS *pVPP);
+  * map a video frame

--- a/gpac-no-zmemcpy.patch
+++ b/gpac-no-zmemcpy.patch
@@ -1,0 +1,12 @@
+diff -up gpac-2.2.1/src/utils/gzio.c.orig gpac-2.2.1/src/utils/gzio.c
+--- gpac-2.2.1/src/utils/gzio.c.orig	2023-04-24 14:57:53.000000000 +0200
++++ gpac-2.2.1/src/utils/gzio.c	2024-03-12 11:40:34.486536168 +0100
+@@ -407,7 +407,7 @@ int gf_gzread(void *file, voidp buf, uns
+ 			uInt n = s->stream.avail_in;
+ 			if (n > s->stream.avail_out) n = s->stream.avail_out;
+ 			if (n > 0) {
+-				zmemcpy(s->stream.next_out, s->stream.next_in, n);
++				memcpy(s->stream.next_out, s->stream.next_in, n);
+ 				next_out += n;
+ 				s->stream.next_out = next_out;
+ 				s->stream.next_in   += n;

--- a/gpac.spec
+++ b/gpac.spec
@@ -17,7 +17,7 @@
 Name:        gpac
 Summary:     MPEG-4 multimedia framework
 Version:     2.2.1
-Release:     5%{?shortcommit0:.%{date}git%{shortcommit0}}%{?dist}
+Release:     6%{?shortcommit0:.%{date}git%{shortcommit0}}%{?dist}
 License:     LGPLv2+
 URL:         https://gpac.sourceforge.net/
 Source0:     https://github.com/gpac/gpac/archive/v%{version}/gpac-%{version}.tar.gz
@@ -25,6 +25,12 @@ Source0:     https://github.com/gpac/gpac/archive/v%{version}/gpac-%{version}.ta
 
 Patch0:      gpac-doxygen_195.patch
 Patch1:      https://github.com/gpac/gpac/commit/ba14e34dd7a3c4cef5a56962898e9f863dd4b4f3.patch#/ffmpeg6.patch
+# zlib-ng doesn't define the zmemcpy macro anymore
+# https://github.com/gpac/gpac/pull/2780
+Patch2:      gpac-no-zmemcpy.patch
+# cuvid device pointers are 64bit on aarch64 as well
+# https://github.com/gpac/gpac/pull/2781
+Patch3:      gpac-aarch64-nvdec.patch
 
 BuildRequires:  SDL2-devel
 BuildRequires:  a52dec-devel
@@ -125,13 +131,7 @@ sed -i 's/dh_link/ln -s -r/' Makefile
   --disable-oss-audio \
 %{?_with_amr:--enable-amr} \
   --enable-pic \
-%if 0%{?fedora} && 0%{?fedora} >= 40
-  --use-zlib=no \
-%ifarch %{arm64}
-  --disable-nvdec \
-%endif
-%endif
-  --verbose 
+  --verbose
 
 #Avoid mess with setup.h
 cp -p config.h include/gpac
@@ -200,6 +200,11 @@ rm %{buildroot}%{_includedir}/gpac/config.h
 
 
 %changelog
+* Tue Mar 12 2024 Dominik Mierzejewski <dominik@greysector.net> - 2.2.1-6
+- re-enable zlib and nvdec
+- fix build with zlib-ng
+- fix building nvdec on aarch64
+
 * Sat Feb 03 2024 RPM Fusion Release Engineering <sergiomb@rpmfusion.org> - 2.2.1-5
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_40_Mass_Rebuild
 

--- a/gpac.spec
+++ b/gpac.spec
@@ -41,6 +41,7 @@ BuildRequires:  faad2-devel
 BuildRequires:  libjpeg-devel
 BuildRequires:  libpng-devel >= 1.2.5
 BuildRequires:  libmad-devel
+BuildRequires:  libnghttp2-devel
 BuildRequires:  xvidcore-devel >= 1.0.0
 BuildRequires:  ffmpeg-devel
 BuildRequires:  libxml2-devel
@@ -205,6 +206,7 @@ rm %{buildroot}%{_includedir}/gpac/config.h
 - fix build with zlib-ng
 - fix building nvdec on aarch64
 - fix OSS audio disablement
+- enable Nghttp2 support
 
 * Sat Feb 03 2024 RPM Fusion Release Engineering <sergiomb@rpmfusion.org> - 2.2.1-5
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_40_Mass_Rebuild

--- a/gpac.spec
+++ b/gpac.spec
@@ -128,7 +128,7 @@ sed -i 's/dh_link/ln -s -r/' Makefile
   --extra-cflags="%{optflags} -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -D_LARGEFILE_SOURCE=1 -D_GNU_SOURCE=1 $(pkg-config --cflags libavformat)" \
   --X11-path=%{_prefix} \
   --libdir=%{_lib} \
-  --disable-oss-audio \
+  --disable-oss \
 %{?_with_amr:--enable-amr} \
   --enable-pic \
   --verbose
@@ -204,6 +204,7 @@ rm %{buildroot}%{_includedir}/gpac/config.h
 - re-enable zlib and nvdec
 - fix build with zlib-ng
 - fix building nvdec on aarch64
+- fix OSS audio disablement
 
 * Sat Feb 03 2024 RPM Fusion Release Engineering <sergiomb@rpmfusion.org> - 2.2.1-5
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_40_Mass_Rebuild

--- a/gpac.spec
+++ b/gpac.spec
@@ -127,6 +127,9 @@ sed -i 's/dh_link/ln -s -r/' Makefile
   --enable-pic \
 %if 0%{?fedora} && 0%{?fedora} >= 40
   --use-zlib=no \
+%ifarch %{arm64}
+  --disable-nvdec \
+%endif
 %endif
   --verbose 
 

--- a/gpac.spec
+++ b/gpac.spec
@@ -125,7 +125,10 @@ sed -i 's/dh_link/ln -s -r/' Makefile
   --disable-oss-audio \
 %{?_with_amr:--enable-amr} \
   --enable-pic \
-  --verbose
+%if 0%{?fedora} && 0%{?fedora} >= 40
+  --use-zlib=no \
+%endif
+  --verbose 
 
 #Avoid mess with setup.h
 cp -p config.h include/gpac

--- a/gpac.spec
+++ b/gpac.spec
@@ -179,13 +179,21 @@ rm %{buildroot}%{_includedir}/gpac/config.h
 %{_bindir}/MPEG4Gen
 %{_bindir}/X3DGen
 %{_datadir}/gpac/
-%{_mandir}/man1/*.1.*
-%{_datadir}/applications/*.desktop
+%{_mandir}/man1/gpac-filters.1.*
+%{_mandir}/man1/gpac.1.*
+%{_mandir}/man1/mp4box.1.*
+%{_datadir}/applications/gpac.desktop
 %{_datadir}/icons/hicolor/*/apps/gpac.png
 
 %files libs
-%{_libdir}/libgpac.so.*
-%{_libdir}/gpac/
+%{_libdir}/libgpac.so.12{,.*}
+%dir %{_libdir}/gpac
+%{_libdir}/gpac/gm_ft_font.so
+%{_libdir}/gpac/gm_jack.so
+%{_libdir}/gpac/gm_pulseaudio.so
+%{_libdir}/gpac/gm_sdl_out.so
+%{_libdir}/gpac/gm_validator.so
+%{_libdir}/gpac/gm_x11_out.so
 
 %files doc
 %doc share/doc/html-libgpac/*
@@ -207,6 +215,7 @@ rm %{buildroot}%{_includedir}/gpac/config.h
 - fix building nvdec on aarch64
 - fix OSS audio disablement
 - enable Nghttp2 support
+- list manpages and libraries explicitly
 
 * Sat Feb 03 2024 RPM Fusion Release Engineering <sergiomb@rpmfusion.org> - 2.2.1-5
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_40_Mass_Rebuild

--- a/gpac.spec
+++ b/gpac.spec
@@ -111,13 +111,12 @@ Static library for gpac.
 
 %prep
 %autosetup -p1
-rm -r extra_lib/
+rm -rv extra_lib/
 pushd share/doc
 # Fix encoding warnings
-cp -p ipmpx_syntax.bt ipmpx_syntax.bt.origine
-iconv -f ISO-8859-1 -t UTF8 ipmpx_syntax.bt.origine >  ipmpx_syntax.bt
-touch -r ipmpx_syntax.bt.origine ipmpx_syntax.bt
-rm -rf share/doc/ipmpx_syntax.bt.origine
+iconv -f ISO-8859-1 -t UTF8 ipmpx_syntax.bt >  ipmpx_syntax.bt.utf8
+touch -r ipmpx_syntax.bt{,.utf8}
+mv ipmpx_syntax.bt{.utf8,}
 popd
 sed -i 's/-O0 $CFLAGS/$CFLAGS/' configure
 sed -i 's/-O3 $CFLAGS/$CFLAGS/' configure
@@ -137,8 +136,8 @@ sed -i 's/dh_link/ln -s -r/' Makefile
 #Avoid mess with setup.h
 cp -p config.h include/gpac
 
-%{make_build} all 
-%{make_build} sggen
+%make_build all
+%make_build sggen
 
 ## kwizart - build doxygen doc for devel
 pushd share/doc
@@ -146,8 +145,7 @@ doxygen
 popd
 
 %install
-%{make_install} install-lib
-rm -rf %{buildroot}%{_bindir}/Osmo4
+%make_install install-lib
 
 #Install generated sggen binaries
 #for b in MPEG4 SVG X3D; do
@@ -167,9 +165,8 @@ touch -r Changelog %{buildroot}%{_includedir}/gpac/*.h
 touch -r Changelog %{buildroot}%{_includedir}/gpac/internal/*.h
 touch -r Changelog %{buildroot}%{_includedir}/gpac/modules/*.h
 rm %{buildroot}%{_includedir}/gpac/config.h
-
-
-%ldconfig_scriptlets libs
+# do not include in gpac, only here to create doxygen group for doc ordering
+rm %{buildroot}%{_includedir}/gpac/00_doxy.h
 
 %files
 %doc Changelog README.md
@@ -216,6 +213,7 @@ rm %{buildroot}%{_includedir}/gpac/config.h
 - fix OSS audio disablement
 - enable Nghttp2 support
 - list manpages and libraries explicitly
+- clean up, avoid using rm -f
 
 * Sat Feb 03 2024 RPM Fusion Release Engineering <sergiomb@rpmfusion.org> - 2.2.1-5
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_40_Mass_Rebuild


### PR DESCRIPTION
- fix build with zlib-ng
- fix building nvdec on aarch64
- fix OSS audio disablement
- enable Nghttp2 support
- list manpages and libraries explicitly
- clean up, avoid using rm -f

NOTE: Leigh's two commits that show up here are actually in RPM Fusion distgit master branch already, just not synced here.